### PR TITLE
Updated encoding for Mammal community db

### DIFF
--- a/scripts/mammal_community_db.json
+++ b/scripts/mammal_community_db.json
@@ -2,6 +2,7 @@
     "citation": "Katherine M. Thibault, Sarah R. Supp, Mikaelle Giffin, Ethan P. White, and S. K. Morgan Ernest. 2011. Species composition and abundance of mammalian communities. Ecology 92:2316.",
     "description": "This data set includes species lists for 1000 mammal communities, excluding bats, with species-level abundances available for 940 of these communities.",
     "homepage": "https://figshare.com/articles/Data_Paper_Data_Paper/3552243",
+    "encoding": "latin-1",
     "keywords": [
         "mammals",
         "global-scale",

--- a/scripts/sanparks_golden_gate_highlands.json
+++ b/scripts/sanparks_golden_gate_highlands.json
@@ -1,0 +1,158 @@
+{
+    "citation": "Golden Gate Highland National Parks Census Data.",
+    "description": "These summary totals were derived from the annual reports on the census results for each year held by the Scientific Services Division of SANParks. Those for 1965-1976 were derived from aerial count totals corrected on the basis of differential ground counts. Those for 1977-1997 were the count totals recorded in the annual “Ecological Aerial Surveys” following a standard methodology.",
+    "homepage": "http://dataknp.sanparks.org/sanparks/metacat/peggym.113.6/sanparks",
+    "encoding": "ISO-8859-1",
+    "keywords": [
+        "SANParks, South Africa",
+        "Golden Gate Highland National Park,South Africa",
+        "Census data"
+    ],
+    "name": "sanparks_golden_highlands",
+    "resources": [
+        {
+            "dialect": {
+                "delimiter": "\t",
+                "missingValues": "NA"
+            },
+            "name": "GGHNPcensusdata.txt",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "ID",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Unique number",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Decimal Deg E",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Decimal Deg S",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Date",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Block / Stratum",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Transect",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Species",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Total number",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Juveniles / calves",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Distance / Strip",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Observer - L/R",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Comments",
+                        "type": "char"
+                    }
+                ]
+            },
+            "url": "http://dataknp.sanparks.org/sanparks/metacat?action=read&qformat=sanparks&sessionid=&docid=peggym.109.1"
+        },
+        {
+            "dialect": {
+                "delimiter": "\t",
+                "missingValues": "NA"
+            },
+            "name": "GGHNPQWAQWATotals.txt",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "Date",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Area",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Common name",
+                        "type": "char"
+                    },
+                    {
+                        "name": "SumOfTotal number",
+                        "type": "double"
+                    }
+                ]
+            },
+            "url": "http://dataknp.sanparks.org/sanparks/metacat?action=read&qformat=sanparks&sessionid=&docid=peggym.110.1"
+        },
+        {
+            "dialect": {
+                "delimiter": "\t",
+                "missingValues": "NA"
+            },
+            "name": "GGHNPSpecieCodes.txt",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "ID",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Common name",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Species ID",
+                        "type": "char"
+                    }
+                ]
+            },
+            "url": "http://dataknp.sanparks.org/sanparks/metacat?action=read&qformat=sanparks&sessionid=&docid=peggym.111.1"
+        },
+        {
+            "dialect": {
+                "delimiter": "\t",
+                "missingValues": "NA"
+            },
+            "name": "GGHNPTotals.txt",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "Column 1",
+                        "type": "date"
+                    },
+                    {
+                        "name": "Column 2",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Column 3",
+                        "type": "char"
+                    }
+                ]
+            },
+            "url": "http://dataknp.sanparks.org/sanparks/metacat?action=read&qformat=sanparks&sessionid=&docid=peggym.112.1"
+        }
+    ],
+    "retriever": "True",
+    "retriever_minimum_version": "2.0.dev",
+    "title": "Golden Gate Highland National Parks Census Data.",
+    "version": "1.0.0"
+}

--- a/scripts/sanparks_karoo.json
+++ b/scripts/sanparks_karoo.json
@@ -1,0 +1,198 @@
+//FIXME: The have some error with it.
+{
+    "citation": "Karoo Natioanal Park Census Data. 1994 - 2009",
+    "description": "Karoo National Park census was not conducted in 2007 and the data is only spatially explicit from 2008",
+    "homepage": "http://dataknp.sanparks.org/sanparks/metacat/peggym.117.10/sanparks",
+    "keywords": [
+        "SANParks, South Africa",
+        "Karoo National Park, South Africa",
+        "Census data"
+    ],
+    "name": "sanparks_karoo",
+    "resources": [
+        {
+            "dialect": {
+                "delimiter": "\t",
+                "missingValues": "NA"
+            },
+            "name": "KarooNationalParkCensuscodes.txt",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "Common name",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Species",
+                        "type": "char"
+                    }
+                ]
+            },
+            "url": "http://dataknp.sanparks.org/sanparks/metacat?action=read&qformat=sanparks&sessionid=&docid=peggym.114.1"
+        },
+        {
+            "dialect": {
+                "delimiter": "\t",
+                "missingValues": "NA"
+            },
+            "name": "KRNPCensusdata.txt",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "ID",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Unique number",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Decimal Deg E",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Decimal Deg S",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Date",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Block / Stratum",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Transect",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Species",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Total number",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Juveniles / calves",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Distance / Strip",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Observer - L/R",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Comments",
+                        "type": "char"
+                    }
+                ]
+            },
+            "url": "http://dataknp.sanparks.org/sanparks/metacat?action=read&qformat=sanparks&sessionid=&docid=peggym.115.1"
+        },
+        {
+            "dialect": {
+                "delimiter": "\t",
+                "missingValues": "NA"
+            },
+            "name": "KRNPTotals.txt",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "Date",
+                        "type": "date"
+                    },
+                    {
+                        "name": "Common name",
+                        "type": "char"
+                    },
+                    {
+                        "name": "SumOfTotal number",
+                        "type": "double"
+                    }
+                ]
+            },
+            "url": "http://dataknp.sanparks.org/sanparks/metacat?action=read&qformat=sanparks&sessionid=&docid=peggym.116.1"
+        },
+        {
+            "dialect": {
+                "delimiter": "\t",
+                "missingValues": "NA"
+            },
+            "name": "karoo2008.txt",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "Date",
+                        "type": "date"
+                    },
+                    {
+                        "name": "CONTROL",
+                        "type": "date"
+                    },
+                    {
+                        "name": "TOTAL",
+                        "type": "date"
+                    },
+                    {
+                        "name": "BULLS",
+                        "type": "date"
+                    },
+                    {
+                        "name": "CALVES",
+                        "type": "date"
+                    },
+                    {
+                        "name": "Longitude",
+                        "type": "date"
+                    },
+                    {
+                        "name": "Latitude",
+                        "type": "date"
+                    }
+                ]
+            },
+            "url": "http://dataknp.sanparks.org/sanparks/metacat?action=read&qformat=sanparks&sessionid=&docid=peggym.115.1"
+        },
+        {
+            "dialect": {
+                "delimiter": "\t",
+                "missingValues": "NA"
+            },
+            "name": "Karoo2006.txt",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "year",
+                        "type": "double"
+                    }
+                ]
+            },
+            "url": "http://dataknp.sanparks.org/sanparks/metacat?action=read&qformat=sanparks&sessionid=&docid=peggym.115.1"
+        },
+        {
+            "dialect": {
+                "delimiter": "\t",
+                "missingValues": "NA"
+            },
+            "name": "Karoo09.txt",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "year",
+                        "type": "double"
+                    }
+                ]
+            },
+            "url": "http://dataknp.sanparks.org/sanparks/metacat?action=read&qformat=sanparks&sessionid=&docid=peggym.115.1"
+        }
+    ],
+    "retriever": "True",
+    "retriever_minimum_version": "2.0.dev",
+    "title": "Karoo Natioanal Park Census Data. 1994 - 2009",
+    "version": "1.0.0"
+}

--- a/scripts/sanparks_kruger.json
+++ b/scripts/sanparks_kruger.json
@@ -1,0 +1,58 @@
+{
+    "citation": "Census totals for large herbivores in the Kruger National Park summarized by year and region 1965-1997",
+    "description": "These summary totals were derived from the annual reports on the census results for each year held by the Scientific Services Division of SANParks. Those for 1965-1976 were derived from aerial count totals corrected on the basis of differential ground counts. Those for 1977-1997 were the count totals recorded in the annual “Ecological Aerial Surveys” following a standard methodology.",
+    "homepage": "http://dataknp.sanparks.org/sanparks/metacat/judithk.814.4/sanparks",
+    "keywords": [
+        "SANParks, South Africa",
+        "Kruger National Park, South Africa",
+        "Census data"
+
+    ],
+    "name": "sanparks_kruger",
+    "resources": [
+        {
+            "dialect": {
+                "delimiter": "\t",
+                "missingValues": "NA"
+            },
+            "name": "judithk.815.1-815.1",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "year",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Species",
+                        "type": "char"
+                    },
+                    {
+                        "name": "South",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Central",
+                        "type": "double"
+                    },
+                    {
+                        "name": "North",
+                        "type": "double"
+                    },
+                    {
+                        "name": "FarNorth",
+                        "type": "double"
+                    },
+                    {
+                        "name": "TOTAL",
+                        "type": "double"
+                    }
+                ]
+            },
+            "url": "http://dataknp.sanparks.org/sanparks/metacat?action=read&qformat=sanparks&sessionid=&docid=judithk.815.1"
+        }
+    ],
+    "retriever": "True",
+    "retriever_minimum_version": "2.0.dev",
+    "title": "Census totals for large herbivores in the Kruger National Park summarized by year and region 1965-1997",
+    "version": "1.0.0"
+}


### PR DESCRIPTION
Added encoding for the dataset in script. `"encoding": "latin-1"`. Attempts to close [#1431](https://github.com/weecology/retriever/issues/1431)