### PR TITLE
Updated mammal-community-db encoding

### DIFF
--- a/scripts/mammal_community_db.json
+++ b/scripts/mammal_community_db.json
@@ -2,6 +2,7 @@
     "citation": "Katherine M. Thibault, Sarah R. Supp, Mikaelle Giffin, Ethan P. White, and S. K. Morgan Ernest. 2011. Species composition and abundance of mammalian communities. Ecology 92:2316.",
     "description": "This data set includes species lists for 1000 mammal communities, excluding bats, with species-level abundances available for 940 of these communities.",
     "homepage": "https://figshare.com/articles/Data_Paper_Data_Paper/3552243",
+    "encoding": "latin-1",
     "keywords": [
         "mammals",
         "global-scale",

--- a/scripts/mammal_community_db.json
+++ b/scripts/mammal_community_db.json
@@ -45,5 +45,5 @@
     "retriever": "True",
     "retriever_minimum_version": "2.0.dev",
     "title": "Mammal Community DataBase (Thibault et al. 2011)",
-    "version": "1.2.1"
+    "version": "1.2.2"
 }

--- a/version.txt
+++ b/version.txt
@@ -116,7 +116,7 @@ lakecats_final_tables.json,2.0.0
 leaf_herbivory.json,1.2.1
 macroalgal_communities.json,2.0.0
 macrocystis_variation.json,1.0.1
-mammal_community_db.json,1.2.1
+mammal_community_db.json,1.2.2
 mammal_diet.json,1.1.2
 mammal_life_hist.json,1.2.1
 mammal_masses.json,1.3.2


### PR DESCRIPTION
Added encoding for the dataset in script. "encoding": "latin-1". Attempts to close[[#1431](https://github.com/weecology/retriever/issues/1431).

