### PR TITLE
Fixed kaggle scripts from #60

### DIFF
--- a/scripts/coronavirus_italy.json
+++ b/scripts/coronavirus_italy.json
@@ -1,0 +1,160 @@
+{
+    "archived": "zip",
+    "citation": "",
+    "description": "Coronavirus Disease 2019 cases in Italy",
+    "homepage": "https://www.kaggle.com/sudalairajkumar/covid19-in-italy",
+    "keywords": [
+        "covid-19",
+        "South Korea",
+        "Coronavirus",
+        "Machine Learning",
+        "kaggle dataset",
+        "Italy"
+    ],
+    "name": "coronavirus-italy",
+    "resources": [
+        {
+            "dialect": {
+                "delimiter": ","
+            },
+            "name": "covid19_italy_region",
+            "path": "covid19_italy_region.csv",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "SNo",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Date",
+                        "type": "date"
+                    },
+                    {
+                        "name": "Country",
+                        "size": "3",
+                        "type": "char"
+                    },
+                    {
+                        "name": "RegionCode",
+                        "type": "double"
+                    },
+                    {
+                        "name": "RegionName",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Latitude",
+                        "type": "float"
+                    },
+                    {
+                        "name": "Longitude",
+                        "type": "float"
+                    },
+                    {
+                        "name": "HospitalizedPatients",
+                        "type": "double"
+                    },
+                    {
+                        "name": "IntensiveCarePatients",
+                        "type": "double"
+                    },
+                    {
+                        "name": "TotalHospitalizedPatients",
+                        "type": "double"
+                    },
+                    {
+                        "name": "HomeConfinement",
+                        "type": "double"
+                    },
+                    {
+                        "name": "CurrentPositiveCases",
+                        "type": "double"
+                    },
+                    {
+                        "name": "NewPositiveCases",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Recovered",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Deaths",
+                        "type": "double"
+                    },
+                    {
+                        "name": "TotalPositiveCases",
+                        "type": "double"
+                    },
+                    {
+                        "name": "TestsPerformed",
+                        "type": "double"
+                    }
+                ]
+            },
+            "url": "sudalairajkumar/covid19-in-italy"
+        },
+        {
+            "dialect": {
+                "delimiter": ","
+            },
+            "name": "covid19_italy_province",
+            "path": "covid19_italy_province.csv",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "SNo",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Date",
+                        "type": "date"
+                    },
+                    {
+                        "name": "Country",
+                        "size": "3",
+                        "type": "char"
+                    },
+                    {
+                        "name": "RegionCode",
+                        "type": "double"
+                    },
+                    {
+                        "name": "RegionName",
+                        "type": "char"
+                    },
+                    {
+                        "name": "ProvinceCode",
+                        "type": "double"
+                    },
+                    {
+                        "name": "ProvinceName",
+                        "type": "char"
+                    },
+                    {
+                        "name": "ProvinceAbbreviation",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Latitude",
+                        "type": "float"
+                    },
+                    {
+                        "name": "Longitude",
+                        "type": "float"
+                    },
+                    {
+                        "name": "TotalPositiveCases",
+                        "type": "double"
+                    }
+                ]
+            },
+            "url": "sudalairajkumar/covid19-in-italy"
+        }
+    ],
+    "kaggle": "True",
+    "data_source": "dataset",
+    "retriever_minimum_version": "2.1.0",
+    "title": "COVID-19 in Italy",
+    "version": "1.0.0"
+}

--- a/scripts/titanic.json
+++ b/scripts/titanic.json
@@ -1,0 +1,158 @@
+{
+    "archived": "zip",
+    "citation": "",
+    "description": "Titanic passenger data use to predict survival on the Titanic",
+    "homepage": "https://www.kaggle.com/c/titanic",
+    "keywords": [
+        "Kaggle",
+        "ML",
+        "Titanic",
+        "Machine Learning",
+        "Disaster",
+        "kaggle competition"
+    ],
+    "name": "titanic",
+    "resources": [
+        {
+            "dialect": {
+                "delimiter": ","
+            },
+            "name": "gender_submission",
+            "path": "gender_submission.csv",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "PassengerId",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Survived",
+                        "type": "double"
+                    }
+                ]
+            },
+            "url": "titanic"
+        },
+        {
+            "dialect": {
+                "delimiter": ","
+            },
+            "name": "train",
+            "path": "train.csv",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "PassengerId",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Survived",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Pclass",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Name",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Sex",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Age",
+                        "type": "double"
+                    },
+                    {
+                        "name": "SibSp",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Parch",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Ticket",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Fare",
+                        "type": "float"
+                    },
+                    {
+                        "name": "Cabin",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Embarked",
+                        "type": "char"
+                    }
+                ]
+            },
+            "url": "titanic"
+        },
+        {
+            "dialect": {
+                "delimiter": ","
+            },
+            "name": "test",
+            "path": "test.csv",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "PassengerId",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Pclass",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Name",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Sex",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Age",
+                        "type": "double"
+                    },
+                    {
+                        "name": "SibSp",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Parch",
+                        "type": "double"
+                    },
+                    {
+                        "name": "Ticket",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Fare",
+                        "type": "float"
+                    },
+                    {
+                        "name": "Cabin",
+                        "type": "char"
+                    },
+                    {
+                        "name": "Embarked",
+                        "type": "char"
+                    }
+                ]
+            },
+            "url": "titanic"
+        }
+    ],
+    "kaggle": "True",
+    "data_source": "competition",
+    "retriever_minimum_version": "2.1.0",
+    "title": "Titanic: Machine Learning from Disaster",
+    "version": "1.2.1"
+}

--- a/version.txt
+++ b/version.txt
@@ -24,6 +24,7 @@ catalogos_dados_brasil.json,1.0.0
 chytr_disease_distr.json,1.0.3
 community_abundance_misc.json,1.0.3
 coronavirus-belgium.json,1.0.0
+coronavirus_italy.json,1.0.0
 coronavirus_south_korea.json,1.0.0
 county_emergency_management_offices.json,1.0.0
 credit_card_fraud.json,1.0.0
@@ -173,6 +174,7 @@ sonoran_desert.json,1.0.0
 species_exctinction_rates.json,1.0.2
 streamflow_conditions.json,1.0.2
 sycamore_creek_macroinvertebrate.json,1.0.0
+titanic.json,1.2.1
 transparencia_dados_abertos_brasil.json,1.0.0
 tree_canopy_geometries.json,1.0.1
 tree_demog_wghats.py,1.3.3


### PR DESCRIPTION
@henrykironde As discussed, this is 2<sup>nd </sup> PR from another author which have following changes :
1. Added keywords like kaggle dataset / kaggle competition
2. Removed `"header_rows": 0` from scripts #60 as its not necessary.

I am not sure about this field `"retriever_minimum_version": "2.1.0"` , is this correct for kaggle competition datasets ?
I have tested the scripts and attaching output images:


- Coronavirus-italy 
![covid19_italy_cli](https://user-images.githubusercontent.com/34245555/107145721-79bf6100-6969-11eb-8e52-570814760407.png)
![covid19_italy_pg](https://user-images.githubusercontent.com/34245555/107145723-7b892480-6969-11eb-8021-019e48f746d2.png)


- Titanic 
![titanic_cli](https://user-images.githubusercontent.com/34245555/107145724-7c21bb00-6969-11eb-8c81-cfad0519a95d.png)
![titanic_pg](https://user-images.githubusercontent.com/34245555/107145725-7cba5180-6969-11eb-9a35-92c8f633366b.png)
