### PR TITLE
Add Covid19 surveillance data

### DIFF
--- a/scripts/covid_case_surveillance.json
+++ b/scripts/covid_case_surveillance.json
@@ -1,0 +1,125 @@
+{
+    "citation": "",
+    "description": "This case surveillance public use dataset has 19 elements for all COVID-19 cases shared with CDC and includes demographics, geography (county and state of residence), any exposure history, disease severity indicators and outcomes, and presence of any underlying medical conditions and risk behaviors.",
+    "encoding": "utf-8",
+    "homepage": "https://dev.socrata.com/foundry/data.cdc.gov/n8mc-b4w4",
+    "keywords": [
+        "covid",
+        "coronavirus",
+        "covid19",
+        "CDC"
+    ],
+    "licenses": [],
+    "name": "covid-case-surveillance",
+    "resources": [
+        {
+            "dialect": {
+                "delimiter": ","
+            },
+            "name": "covid_19_case_surveillance",
+            "path": "COVID-19_Case_Surveillance_Public_Use_Data_with_Geography.csv",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "case_month",
+                        "size": "7",
+                        "type": "char"
+                    },
+                    {
+                        "name": "res_state",
+                        "size": "2",
+                        "type": "char"
+                    },
+                    {
+                        "name": "state_fips_code",
+                        "size": "2",
+                        "type": "char"
+                    },
+                    {
+                        "name": "res_county",
+                        "size": "20",
+                        "type": "char"
+                    },
+                    {
+                        "name": "county_fips_code",
+                        "size": "5",
+                        "type": "char"
+                    },
+                    {
+                        "name": "age_group",
+                        "size": "14",
+                        "type": "char"
+                    },
+                    {
+                        "name": "sex",
+                        "size": "7",
+                        "type": "char"
+                    },
+                    {
+                        "name": "race",
+                        "size": "38",
+                        "type": "char"
+                    },
+                    {
+                        "name": "ethnicity",
+                        "size": "19",
+                        "type": "char"
+                    },
+                    {
+                        "name": "case_positive_specimen_interval",
+                        "type": "int"
+                    },
+                    {
+                        "name": "case_onset_interval",
+                        "type": "int"
+                    },
+                    {
+                        "name": "process",
+                        "size": "32",
+                        "type": "char"
+                    },
+                    {
+                        "name": "exposure_yn",
+                        "size": "7",
+                        "type": "char"
+                    },
+                    {
+                        "name": "current_status",
+                        "size": "25",
+                        "type": "char"
+                    },
+                    {
+                        "name": "symptom_status",
+                        "size": "12",
+                        "type": "char"
+                    },
+                    {
+                        "name": "hosp_yn",
+                        "size": "7",
+                        "type": "char"
+                    },
+                    {
+                        "name": "icu_yn",
+                        "size": "7",
+                        "type": "char"
+                    },
+                    {
+                        "name": "death_yn",
+                        "size": "7",
+                        "type": "char"
+                    },
+                    {
+                        "name": "underlying_conditions_yn",
+                        "size": "3",
+                        "type": "char"
+                    }
+                ]
+            },
+            "url": "https://data.cdc.gov/api/views/n8mc-b4w4/rows.csv?accessType=DOWNLOAD&api_foundry=true"
+        }
+    ],
+    "retriever": "True",
+    "retriever_minimum_version": "2.1.0",
+    "title": "COVID-19 Case Surveillance Public Use Data with Geography",
+    "version": "1.0.0"
+}

--- a/version.txt
+++ b/version.txt
@@ -33,6 +33,7 @@ coronavirus-belgium.json,1.0.0
 coronavirus_italy.json,1.0.0
 coronavirus_south_korea.json,1.0.0
 county_emergency_management_offices.json,1.0.0
+covid_case_surveillance.json,1.0.0
 credit_card_fraud.json,1.0.0
 croche_vegetation_data.json,1.0.2
 dicerandra_frutescens.json,1.0.2


### PR DESCRIPTION
Adds the dataset requested in https://github.com/weecology/retriever/issues/1582

New dataset is named covid-case-surveillance

Tested with `retriever ls` and install to postgres. 
![2021-05-14_19-22](https://user-images.githubusercontent.com/53650538/118289124-a51a9480-b4f2-11eb-930b-e151cf828ed8.png)
![2021-05-14_20-21](https://user-images.githubusercontent.com/53650538/118289149-a9df4880-b4f2-11eb-80b7-f1e13583a288.png)
![2021-05-14_20-27](https://user-images.githubusercontent.com/53650538/118289343-e0b55e80-b4f2-11eb-8095-3067a8a66be1.png)


Note: Many of the data values seen might be NA but that is just the nature of the first few rows of data.

